### PR TITLE
fix: paginate getAccounts to handle Firefly instances with >50 accounts

### DIFF
--- a/src/firefly.js
+++ b/src/firefly.js
@@ -68,8 +68,9 @@ export function deleteTx(id) {
   return fireflyAxios.delete(`/api/v1/transactions/${id}`);
 }
 
-export function getAccounts() {
-  return fireflyAxios.get('/api/v1/accounts');
+export async function getAccounts() {
+  const data = await paginate('/api/v1/accounts');
+  return { data: { data } };
 }
 
 export function createAccount(data) {


### PR DESCRIPTION
## Problem

getAccounts() issued a single non-paginated GET to /api/v1/accounts. Firefly III's accounts endpoint returns all account types (asset, expense, revenue, liability) together and defaults to 50 results per page.

Users who have accumulated more than 50 expense accounts — common in setups where each merchant or payee gets its own expense account — will see their asset accounts pushed onto page 2+. Because getAccounts() never fetched subsequent pages, those asset accounts were invisible to the importer.

createAndMapAccounts() then treated those existing-but-invisible asset accounts as missing and called POST /api/v1/accounts to create them. Firefly III rejected this with:

> HTTP 422: It looks like this account number is already in use.

## Fix

Delegate getAccounts() to the existing paginate() helper (already used by searchTxs, getAllTxs, and getTxsByTag) so all pages are fetched and every account is visible regardless of total count. The return shape is kept identical to what callers expect ({ data: { data: [...] } }).

## Triggering condition

Any Firefly III instance where the total number of accounts across all types exceeds 50 (the default page size) and asset accounts happen to sort past the first page.