### PR TITLE
ci(release): switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -23,6 +26,6 @@ jobs:
             @codedependant/semantic-release-docker@4.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}


### PR DESCRIPTION
## Summary
- Adds `id-token: write` permission to the release job
- Replaces `NPM_TOKEN` secret with `NPM_CONFIG_PROVENANCE: true` to use npm OIDC trusted publishing

## Test plan
- [ ] Verify npm trusted publisher is configured on npmjs.com for this package
- [ ] Confirm release workflow passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)