### PR TITLE
ci(release): upgrade to @semantic-release/npm v13 with native OIDC support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,16 +16,19 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Upgrade npm
+        run: npm install -g npm@^11.5.1
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
         with:
+          semantic_version: 25.0.5
           extra_plugins: |
             @semantic-release/changelog@6.0.2
             @semantic-release/git@10.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
+      - name: Get npm OIDC token
+        run: |
+          TOKEN=$(curl -s \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm" \
+            | jq -r '.value')
+          echo "NPM_TOKEN=$TOKEN" >> "$GITHUB_ENV"
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,18 +12,17 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Get npm OIDC token
-        run: |
-          TOKEN=$(curl -s \
-            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm" \
-            | jq -r '.value')
-          echo "NPM_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         with:
@@ -31,8 +30,8 @@ jobs:
             @semantic-release/changelog@6.0.2
             @semantic-release/git@10.0.1
             @codedependant/semantic-release-docker@4.3.0
+            @semantic-release/npm@13.1.5
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
           DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
           DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,4 +1,4 @@
-semantic_version: 19.0.5
+semantic_version: 25.0.5
 plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,4 +1,3 @@
-semantic_version: 25.0.5
 plugins:
   - '@semantic-release/commit-analyzer'
   - '@semantic-release/release-notes-generator'


### PR DESCRIPTION
## Summary
- Upgrades `semantic-release` 19 → 25.0.5 (required by `@semantic-release/npm@13`)
- Pins `@semantic-release/npm@13.1.5` which natively handles npm Trusted Publishers OIDC in `verifyConditions` via `@actions/core.getIDToken` — no `NPM_TOKEN` secret needed
- Adds `actions/setup-node@v4` with Node 22 (requirement: node ≥ 22.14, npm ≥ 11.5.1)
- Adds `issues: write` / `pull-requests: write` permissions to fix `@semantic-release/github` 403 error
- Removes `NPM_CONFIG_PROVENANCE` (automatic with `@semantic-release/npm@13+`)

## How OIDC works now
`@semantic-release/npm@13.1.0+` calls `@actions/core.getIDToken("npm:registry.npmjs.org")` in `verifyConditions`. When the package has a Trusted Publisher configured on npmjs.com and `id-token: write` is set, it exchanges the OIDC JWT for a short-lived npm automation token internally — no stored secret required.

## Test plan
- [ ] Verify npm Trusted Publisher is configured on npmjs.com for this package pointing to this repo + workflow
- [ ] Confirm `verifyConditions` passes without `NPM_TOKEN` in the next release run
- [ ] Confirm Docker publish still works (unrelated to npm OIDC changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)