### PR TITLE
fix(docker): chown copied files to pptruser to fix permission denied

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,10 @@ RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
 USER pptruser
 
 WORKDIR /home/pptruser/app
-COPY ["package.json", "package-lock.json*", "./"]
+COPY --chown=pptruser:pptruser ["package.json", "package-lock.json*", "./"]
 
 RUN npm ci
 # the rest of your dockerfile here
-COPY . .
+COPY --chown=pptruser:pptruser . .
 
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- `COPY` runs as `root` regardless of the active `USER` directive, so files copied after `USER pptruser` (both `COPY package.json...` and `COPY . .`) were owned by `root:root` instead of `pptruser`.
- This causes `EACCES: permission denied` when `pptruser` tries to write to those paths at runtime — e.g. `config/` (where the README instructs users to mount `config.yaml`) or `src/`.
- Fix: add `--chown=pptruser:pptruser` to both `COPY` instructions, as suggested in the issue.

## Verification
Built the image before and after the fix and confirmed via `docker run`:
- Before: `ls -la` showed `root root` ownership on copied files/dirs; `touch config/testfile` → `Permission denied`.
- After: all copied files/dirs owned by `pptruser`; writes to `config/` and `src/` succeed; app still starts and reaches normal config-validation logic.

Fixes #279

## Test plan
- [x] `docker build` succeeds
- [x] Reproduced the permission bug on the unpatched Dockerfile
- [x] Confirmed the fix resolves it (writable `config/`, `src/`; correct `pptruser` ownership)
- [x] Confirmed `npm start` still runs and reaches expected config-validation error with no config supplied

🤖 Generated with [Claude Code](https://claude.com/claude-code)